### PR TITLE
Add parking space comparison

### DIFF
--- a/src/backend/backend-postgresql-api/build.gradle
+++ b/src/backend/backend-postgresql-api/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'org.hibernate.orm:hibernate-spatial:6.3.1.Final'
 	implementation 'com.opencsv:opencsv:5.8'
 	implementation 'org.apache.commons:commons-io:1.3.2'
+	implementation 'org.locationtech.jts:jts-core:1.19.0'
 }
 
 tasks.named('test') {

--- a/src/backend/backend-postgresql-api/src/main/java/org/gradle/backendpostgresqlapi/DatabaseConnection.java
+++ b/src/backend/backend-postgresql-api/src/main/java/org/gradle/backendpostgresqlapi/DatabaseConnection.java
@@ -3,6 +3,7 @@ package org.gradle.backendpostgresqlapi;
 import lombok.extern.slf4j.Slf4j;
 
 import org.gradle.backendpostgresqlapi.entity.EditedParkingSpace;
+import org.gradle.backendpostgresqlapi.entity.ParkingSpace;
 import org.gradle.backendpostgresqlapi.service.EditedParkingSpaceService;
 import org.gradle.backendpostgresqlapi.service.ParkingSpaceService;
 import org.springframework.boot.ApplicationRunner;
@@ -40,8 +41,11 @@ public class DatabaseConnection {
                 editedParkingSpaceService.copyDataIntoDatabase();
 
             // Now retrieve and print all edited parking spaces.
-            List<EditedParkingSpace> editedParkingSpaces = editedParkingSpaceService.getAllEditedParkingSpaces();
-            editedParkingSpaces.forEach(eps -> System.out.println(eps.toString()));
+            //List<EditedParkingSpace> editedParkingSpaces = editedParkingSpaceService.getAllEditedParkingSpaces();
+            //editedParkingSpaces.forEach(eps -> System.out.println(eps.toString()));
+
+            List<ParkingSpace> parkingSpaces = parkingSpaceService.getAllParkingSpaces();
+            parkingSpaces.forEach(parkingSpace -> System.out.println(parkingSpace.toString()));
         };
     }
 }

--- a/src/backend/backend-postgresql-api/src/main/java/org/gradle/backendpostgresqlapi/DatabaseConnection.java
+++ b/src/backend/backend-postgresql-api/src/main/java/org/gradle/backendpostgresqlapi/DatabaseConnection.java
@@ -41,11 +41,11 @@ public class DatabaseConnection {
                 editedParkingSpaceService.copyDataIntoDatabase();
 
             // Now retrieve and print all edited parking spaces.
-            //List<EditedParkingSpace> editedParkingSpaces = editedParkingSpaceService.getAllEditedParkingSpaces();
-            //editedParkingSpaces.forEach(eps -> System.out.println(eps.toString()));
+            List<EditedParkingSpace> editedParkingSpaces = editedParkingSpaceService.getAllEditedParkingSpaces();
+            editedParkingSpaces.forEach(eps -> System.out.println(eps.toString()));
 
-            List<ParkingSpace> parkingSpaces = parkingSpaceService.getAllParkingSpaces();
-            parkingSpaces.forEach(parkingSpace -> System.out.println(parkingSpace.toString()));
+            //List<ParkingSpace> parkingSpaces = parkingSpaceService.getAllParkingSpaces();
+            //parkingSpaces.forEach(parkingSpace -> System.out.println(parkingSpace.toString()));
         };
     }
 }

--- a/src/backend/backend-postgresql-api/src/main/java/org/gradle/backendpostgresqlapi/entity/EditedParkingSpace.java
+++ b/src/backend/backend-postgresql-api/src/main/java/org/gradle/backendpostgresqlapi/entity/EditedParkingSpace.java
@@ -47,7 +47,7 @@ public class EditedParkingSpace {
     public String toString() {
         return "EditedParkingSpace{" +
                     "id=" + id +
-                    ", parkingSpaceId" + parkingSpaceId +
+                    ", parkingSpaceId=" + parkingSpaceId +
                     ", coordinates=" + coordinatesToString(polygon) +
                     ", isOccupied=" + occupied +
                     ", area=" + area +

--- a/src/backend/backend-postgresql-api/src/main/java/org/gradle/backendpostgresqlapi/repository/EditedParkingSpaceRepo.java
+++ b/src/backend/backend-postgresql-api/src/main/java/org/gradle/backendpostgresqlapi/repository/EditedParkingSpaceRepo.java
@@ -21,4 +21,6 @@ public interface EditedParkingSpaceRepo extends JpaRepository<EditedParkingSpace
     void updateAreaColumnById(@Param("id") long id);
 
     List<EditedParkingSpace> findByOccupied(boolean occupied);
+
+    boolean existsByParkingSpaceId(long id);
 }

--- a/src/backend/backend-postgresql-api/src/main/java/org/gradle/backendpostgresqlapi/repository/ParkingSpaceRepo.java
+++ b/src/backend/backend-postgresql-api/src/main/java/org/gradle/backendpostgresqlapi/repository/ParkingSpaceRepo.java
@@ -4,6 +4,7 @@ import org.gradle.backendpostgresqlapi.entity.ParkingSpace;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +16,7 @@ public interface ParkingSpaceRepo extends JpaRepository<ParkingSpace, Long> {
 
     String CREATE_MAIN_DATA_INDEX_SQL = "CREATE INDEX IF NOT EXISTS ps_coordinates_idx ON parking_spaces USING GIST (ps_coordinates)";
     String UPDATE_AREA_SQL = "UPDATE parking_spaces SET ps_area = ROUND(CAST(ST_AREA(ps_coordinates) AS NUMERIC),2) WHERE ps_area = 0.0";
+    String COUNT_NUM_OF_POLYGONS = "SELECT COUNT(*) FROM parking_spaces WHERE ST_Equals(cast(ps_coordinates as geometry), ST_GeomFromText(:polygonToCompareWith, 4326))";
 
     @Modifying
     @Query(value = CREATE_MAIN_DATA_INDEX_SQL, nativeQuery = true)
@@ -30,4 +32,8 @@ public interface ParkingSpaceRepo extends JpaRepository<ParkingSpace, Long> {
         parkingSpace.setPolygon(polygon);
         this.save(parkingSpace);
     }
+
+    @Query(value = COUNT_NUM_OF_POLYGONS, nativeQuery = true)
+    long countSamePolygons(@Param("polygonToCompareWith") String polygonToCompareWith);
+    
 }

--- a/src/backend/backend-postgresql-api/src/main/java/org/gradle/backendpostgresqlapi/repository/ParkingSpaceRepo.java
+++ b/src/backend/backend-postgresql-api/src/main/java/org/gradle/backendpostgresqlapi/repository/ParkingSpaceRepo.java
@@ -16,7 +16,7 @@ public interface ParkingSpaceRepo extends JpaRepository<ParkingSpace, Long> {
 
     String CREATE_MAIN_DATA_INDEX_SQL = "CREATE INDEX IF NOT EXISTS ps_coordinates_idx ON parking_spaces USING GIST (ps_coordinates)";
     String UPDATE_AREA_SQL = "UPDATE parking_spaces SET ps_area = ROUND(CAST(ST_AREA(ps_coordinates) AS NUMERIC),2) WHERE ps_area = 0.0";
-    String COUNT_NUM_OF_POLYGONS = "SELECT COUNT(*) FROM parking_spaces WHERE ST_Equals(cast(ps_coordinates as geometry), ST_GeomFromText(:polygonToCompareWith, 4326))";
+    String COUNT_NUM_OF_POLYGONS = "SELECT COUNT(*) FROM parking_spaces WHERE ST_Equals(cast(ps_coordinates as geometry), ST_GeomFromText(:polygonToCompareWith, 4326)) LIMIT 1";
 
     @Modifying
     @Query(value = CREATE_MAIN_DATA_INDEX_SQL, nativeQuery = true)
@@ -35,5 +35,4 @@ public interface ParkingSpaceRepo extends JpaRepository<ParkingSpace, Long> {
 
     @Query(value = COUNT_NUM_OF_POLYGONS, nativeQuery = true)
     long countSamePolygons(@Param("polygonToCompareWith") String polygonToCompareWith);
-    
 }

--- a/src/backend/backend-postgresql-api/src/main/java/org/gradle/backendpostgresqlapi/service/EditedParkingSpaceService.java
+++ b/src/backend/backend-postgresql-api/src/main/java/org/gradle/backendpostgresqlapi/service/EditedParkingSpaceService.java
@@ -29,12 +29,21 @@ public class EditedParkingSpaceService {
         this.editedParkingSpaceRepo = editedParkingSpaceRepo;
     }
 
-    public void copyDataIntoDatabase() throws IOException{
+    public void copyDataIntoDatabase() throws IOException {
         for (long i = 1; i <= parkingSpaceRepo.count(); i++) {
             Optional<ParkingSpace> parkingSpace = parkingSpaceRepo.findById(i);
             if (parkingSpace.isPresent()) {
-                EditedParkingSpace editedParkingSpace = convertToEditedParkingSpace(parkingSpace.get());
-                editedParkingSpaceRepo.save(editedParkingSpace);
+                ParkingSpace existingParkingSpace = parkingSpace.get();
+                
+                // Check if the parking space with the same polygon already exists in the second database
+                boolean isDuplicate = editedParkingSpaceRepo.existsById(existingParkingSpace.getId());
+    
+                if (!isDuplicate) {
+                    EditedParkingSpace editedParkingSpace = convertToEditedParkingSpace(existingParkingSpace);
+                    editedParkingSpaceRepo.save(editedParkingSpace);
+                } else {
+                    log.warn("Parking space from first table not copied! A parking space with the same id already exists in the '{}' table.", TABLE_NAME);
+                }
             } else {
                 throw new IOException(String.format("Error on copying data into '%s'.", TABLE_NAME));
             }

--- a/src/backend/backend-postgresql-api/src/main/java/org/gradle/backendpostgresqlapi/service/EditedParkingSpaceService.java
+++ b/src/backend/backend-postgresql-api/src/main/java/org/gradle/backendpostgresqlapi/service/EditedParkingSpaceService.java
@@ -34,9 +34,9 @@ public class EditedParkingSpaceService {
             Optional<ParkingSpace> parkingSpace = parkingSpaceRepo.findById(i);
             if (parkingSpace.isPresent()) {
                 ParkingSpace existingParkingSpace = parkingSpace.get();
-                
-                // Check if the parking space with the same polygon already exists in the second database
-                boolean isDuplicate = editedParkingSpaceRepo.existsById(existingParkingSpace.getId());
+
+                // Check if a parking space with reference to the current id already exists in the second database
+                boolean isDuplicate = editedParkingSpaceRepo.existsByParkingSpaceId(existingParkingSpace.getId());
     
                 if (!isDuplicate) {
                     EditedParkingSpace editedParkingSpace = convertToEditedParkingSpace(existingParkingSpace);

--- a/src/backend/backend-postgresql-api/src/main/java/org/gradle/backendpostgresqlapi/service/ParkingSpaceService.java
+++ b/src/backend/backend-postgresql-api/src/main/java/org/gradle/backendpostgresqlapi/service/ParkingSpaceService.java
@@ -8,6 +8,7 @@ import org.gradle.backendpostgresqlapi.repository.ParkingSpaceRepo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.opencsv.exceptions.CsvValidationException;
 import java.io.IOException;
@@ -18,6 +19,7 @@ import static org.gradle.backendpostgresqlapi.util.CsvHandler.*;
 
 
 import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.io.WKTWriter;
 import org.springframework.util.CollectionUtils;
 import org.apache.commons.io.FilenameUtils;
 
@@ -61,11 +63,15 @@ public class ParkingSpaceService {
                     default -> log.warn("Unsupported file format for file: {}", filePath);
                 }
             }
-            log.info("Data loading into '{}' is completed.", TABLE_NAME);
+            log.info("Successfully loaded all data in '{}'.", TABLE_NAME);
         } else {
             log.warn("No data files configured for loading.");
         }
     }
+
+    public List<ParkingSpace> getAllParkingSpaces() {
+        return parkingSpaceRepo.findAll();
+    }   
 
     /**
      * Loads data from a GeoJSON file into the database. The method
@@ -78,7 +84,11 @@ public class ParkingSpaceService {
         log.debug("Loading GeoJSON data into '{}' table...", TABLE_NAME);
         String geoJsonData = getJsonDataFromFile(resourceLoader, filePath);
         for (Polygon polygon : getPolygonsFromGeoJson(geoJsonData)) {
-            parkingSpaceRepo.insertParkingSpaceFromPolygon(polygon);
+            if (isPolygonUnique(polygon)) {
+                parkingSpaceRepo.insertParkingSpaceFromPolygon(polygon);
+            } else {
+                log.warn("Duplicate polygon found and skipped: {}", polygon);
+            }
         }
         log.info("GeoJSON data loading into '{}' table is completed.", TABLE_NAME);
     }
@@ -94,7 +104,13 @@ public class ParkingSpaceService {
     private void loadCsv(String filePath) throws IOException, CsvValidationException {
         log.debug("Loading CSV data into '{}' table...", TABLE_NAME);
         List<ParkingSpace> csvParkingSpaces = getCsvDataFromFile(resourceLoader, filePath);
-        parkingSpaceRepo.saveAll(csvParkingSpaces);
+        for (ParkingSpace parkingSpace : csvParkingSpaces) {
+            if (isPolygonUnique(parkingSpace.getPolygon())) {
+                parkingSpaceRepo.save(parkingSpace);
+            } else {
+                log.warn("Duplicate polygon found and skipped: {}", parkingSpace.getPolygon());
+            }
+        }
         log.info("CSV data loading into '{}' table is completed.", TABLE_NAME);
     }
 
@@ -102,5 +118,16 @@ public class ParkingSpaceService {
         log.debug("Calculating and updating area column in '{}' table...", TABLE_NAME);
         parkingSpaceRepo.updateAreaColumn();
         log.info("Area column values were calculated and set accordingly for '{}'.", TABLE_NAME);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isPolygonUnique(Polygon newPolygon) {
+        // Convert the new polygon to WKT (Well-Known Text)
+        String newPolygonWKT = new WKTWriter().write(newPolygon);
+
+        // Use a spatial query to check for duplicates using the index
+        long count = parkingSpaceRepo.countSamePolygons(newPolygonWKT);
+
+        return count == 0; // If count is 0, the polygon is unique
     }
 }

--- a/src/backend/backend-postgresql-api/src/main/java/org/gradle/backendpostgresqlapi/service/ParkingSpaceService.java
+++ b/src/backend/backend-postgresql-api/src/main/java/org/gradle/backendpostgresqlapi/service/ParkingSpaceService.java
@@ -87,7 +87,7 @@ public class ParkingSpaceService {
             if (isPolygonUnique(polygon)) {
                 parkingSpaceRepo.insertParkingSpaceFromPolygon(polygon);
             } else {
-                log.warn("Duplicate polygon found and skipped: {}", polygon);
+                log.warn("Parking space from GeoJSON file not loaded and skipped! A parking space with the same polygon already exists in the '{}' table.", TABLE_NAME);
             }
         }
         log.info("GeoJSON data loading into '{}' table is completed.", TABLE_NAME);
@@ -108,7 +108,7 @@ public class ParkingSpaceService {
             if (isPolygonUnique(parkingSpace.getPolygon())) {
                 parkingSpaceRepo.save(parkingSpace);
             } else {
-                log.warn("Duplicate polygon found and skipped: {}", parkingSpace.getPolygon());
+                log.warn("Parking space from CSV file not loaded and skipped! A parking space with the same polygon already exists in the '{}' table.", TABLE_NAME);
             }
         }
         log.info("CSV data loading into '{}' table is completed.", TABLE_NAME);

--- a/src/backend/backend-postgresql-api/src/main/java/org/gradle/backendpostgresqlapi/service/ParkingSpaceService.java
+++ b/src/backend/backend-postgresql-api/src/main/java/org/gradle/backendpostgresqlapi/service/ParkingSpaceService.java
@@ -120,8 +120,7 @@ public class ParkingSpaceService {
         log.info("Area column values were calculated and set accordingly for '{}'.", TABLE_NAME);
     }
 
-    @Transactional(readOnly = true)
-    public boolean isPolygonUnique(Polygon newPolygon) {
+    private boolean isPolygonUnique(Polygon newPolygon) {
         // Convert the new polygon to WKT (Well-Known Text)
         String newPolygonWKT = new WKTWriter().write(newPolygon);
 

--- a/src/backend/backend-postgresql-api/src/main/java/org/gradle/backendpostgresqlapi/service/ParkingSpaceService.java
+++ b/src/backend/backend-postgresql-api/src/main/java/org/gradle/backendpostgresqlapi/service/ParkingSpaceService.java
@@ -8,7 +8,6 @@ import org.gradle.backendpostgresqlapi.repository.ParkingSpaceRepo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.opencsv.exceptions.CsvValidationException;
 import java.io.IOException;


### PR DESCRIPTION
## What this PR does
* Adds `getAllParkingSpaces()` method back to _ParkingSpaceService_ in order to enable printing of ground truth DB for debugging purposes
* Implements uniqueness check for parking spaces which are being loaded from the datasets
* Implements `countSamePolygons()` in _ParkingSpaceRepo_ which counts how many parking spaces with the same polygon already exist in the DB - if it's 0, then there's no identical parking spaces (currently using the PostGIS index on the `geography` column to search through the polygons)

## TODO
- Uniqueness check for parking spaces which are being received from the API layer
- Uniqueness check for second DB

## Related Issues
* Closes #17 